### PR TITLE
Point the PyPI package name in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ The last stable release is available on github and can be installed with ``pip``
     $ git clone https://github.com/rqlite/pyrqlite.git
     $ pip install ./pyrqlite
 
-Ofter are released on PyPI too, able to be installed via the package named ``rqlite``::
+Often they are released on PyPI too, able to be installed via the package named ``rqlite``::
 
     $ pip install rqlite
 

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,10 @@ The last stable release is available on github and can be installed with ``pip``
     $ git clone https://github.com/rqlite/pyrqlite.git
     $ pip install ./pyrqlite
 
+Ofter are released on PyPI too, able to be installed via the package named ``rqlite``::
+
+    $ pip install rqlite
+
 Alternatively (e.g. if ``pip`` is not available), a tarball can be downloaded
 from GitHub and installed with Setuptools::
 


### PR DESCRIPTION
As promised on https://github.com/rqlite/pyrqlite/issues/5#issuecomment-271545420, this updates the README with installation instructions via PyPI directly