### PR TITLE
_convert_to_python: pass through unicode text by default

### DIFF
--- a/src/test/test_types.py
+++ b/src/test/test_types.py
@@ -51,7 +51,7 @@ class SqliteTypeTests(unittest.TestCase):
         self.cur.execute("insert into test(s) values (?)", ("Österreich",))
         self.cur.execute("select s from test")
         row = self.cur.fetchone()
-        self.assertEqual(row[0], "Österreich")
+        self.assertEqual(row[0], u"Österreich")
 
     def test_CheckSmallInt(self):
         self.cur.execute("insert into test(i) values (?)", (42,))


### PR DESCRIPTION
Python's sqlite3 module has a text_factory attribute which
returns unicode by default, therefore allow unicode strings
to pass through for types with TEXT affinity (according to
sqlite rules) when no converter matches.

This addresses an issue with the NVARCHAR type being decoded
as base64 by default, as discussed in https://github.com/rqlite/sqlalchemy-rqlite/issues/2.

@alanjds 
