### PR TITLE
Additional DB-API compatibility: named parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,9 @@ To run all the tests, execute the script ``setup.py``::
 
     $ python setup.py test
 
+[pytest](https://pytest.org/) is required to run the test suite. pytest can be
+installed with ``pip``
+
 Example
 -------
 
@@ -61,20 +64,32 @@ The following code creates a connection and executes some statements:
             cursor.executemany('INSERT INTO foo(name) VALUES(?)', seq_of_parameters=(('a',), ('b',)))
 
         with connection.cursor() as cursor:
-            # Read a single record
+            # Read a single record with qmark parameter style
             sql = "SELECT `id`, `name` FROM `foo` WHERE `name`=?"
             cursor.execute(sql, ('a',))
+            result = cursor.fetchone()
+            print(result)
+            # Read a single record with named parameter style
+            sql = "SELECT `id`, `name` FROM `foo` WHERE `name`=:name"
+            cursor.execute(sql, {'name': 'b'})
             result = cursor.fetchone()
             print(result)
     finally:
         connection.close()
 
-This example will print:
-
 .. code:: python
 
+This example will print:
+
+
     OrderedDict([('id', 1), ('name', 'a')])
+    OrderedDict([('id', 2), ('name', 'b')])
     
+Paramstyle
+---------
+
+Only qmark and named paramstyles (as defined in PEP 249) are supported. 
+
 Limitations
 ---------
 Transactions are not supported.

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ To run all the tests, execute the script ``setup.py``::
 
     $ python setup.py test
 
-[pytest](https://pytest.org/) is required to run the test suite. pytest can be
-installed with ``pip``
+[pytest](https://pytest.org/) and pytest-cov are required to run the test
+suite. They can both be installed with ``pip``
 
 Example
 -------

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -94,7 +94,10 @@ class ModuleTests(unittest.TestCase):
 class ConnectionTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.cx = sqlite.connect(":memory:")
+        cls.cx = sqlite.connect(
+            host='host1',
+            port=4001,
+        )
 
     def setUp(self):
         cu = self.cx.cursor()
@@ -163,7 +166,10 @@ class ConnectionTests(unittest.TestCase):
 class CursorTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.cx = sqlite.connect(":memory:")
+        cls.cx = sqlite.connect(
+            host='host1',
+            port=4001,
+        )
 
     def setUp(self):
         self.cu = self.cx.cursor()
@@ -287,14 +293,12 @@ class CursorTests(unittest.TestCase):
         row = self.cu.fetchone()
         self.assertEqual(row[0], "foo")
 
-    @unittest.skip('named paramstyle is not implemented')
     def test_CheckExecuteDictMapping(self):
         self.cu.execute("insert into test(name) values ('foo')")
         self.cu.execute("select name from test where name=:name", {"name": "foo"})
         row = self.cu.fetchone()
         self.assertEqual(row[0], "foo")
 
-    @unittest.skip('named paramstyle is not implemented')
     def test_CheckExecuteDictMapping_Mapping(self):
         # Test only works with Python 2.5 or later
         if sys.version_info < (2, 5, 0):
@@ -309,7 +313,6 @@ class CursorTests(unittest.TestCase):
         row = self.cu.fetchone()
         self.assertEqual(row[0], "foo")
 
-    @unittest.skip('named paramstyle is not implemented')
     def test_CheckExecuteDictMappingTooLittleArgs(self):
         self.cu.execute("insert into test(name) values ('foo')")
         try:
@@ -318,7 +321,6 @@ class CursorTests(unittest.TestCase):
         except sqlite.ProgrammingError:
             pass
 
-    @unittest.skip('named paramstyle is not implemented')
     def test_CheckExecuteDictMappingNoArgs(self):
         self.cu.execute("insert into test(name) values ('foo')")
         try:
@@ -327,7 +329,14 @@ class CursorTests(unittest.TestCase):
         except sqlite.ProgrammingError:
             pass
 
-    @unittest.skip('named paramstyle is not implemented')
+    def test_CheckExecuteNamedWithoutDict(self):
+        self.cu.execute("insert into test(name) values ('foo')")
+        try:
+            self.cu.execute("select name from test where name=:name", ("name",))
+            self.fail("should have raised ProgrammingError")
+        except sqlite.ProgrammingError:
+            pass
+
     def test_CheckExecuteDictMappingUnnamed(self):
         self.cu.execute("insert into test(name) values ('foo')")
         try:
@@ -559,7 +568,10 @@ class ConstructorTests(unittest.TestCase):
 class ExtensionTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.con = sqlite.connect(":memory:")
+        cls.con = sqlite.connect(
+            host='host1',
+            port=4001,
+        )
 
     def tearDown(self):
         for row in self.con.execute(
@@ -642,7 +654,7 @@ class ExtensionTests(unittest.TestCase):
 class ClosedConTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.con = sqlite.connect(":memory:")
+        cls.con = sxxxqlite.connect(":memory:")
         cls.cur = cls.con.cursor()
         cls.con.close()
 
@@ -756,7 +768,10 @@ class ClosedConTests(unittest.TestCase):
 class ClosedCurTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.con = sqlite.connect(":memory:")
+        cls.con = sqlite.connect(
+            host='host1',
+            port=4001,
+        )
         cls.cur = cls.con.cursor()
         cls.cur.close()
 

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -256,7 +256,6 @@ class CursorTests(unittest.TestCase):
         except sqlite.ProgrammingError:
             pass
 
-    @unittest.expectedFailure
     def test_CheckExecuteWrongNoOfArgs2(self):
         # too little parameters
         try:
@@ -265,7 +264,6 @@ class CursorTests(unittest.TestCase):
         except sqlite.ProgrammingError:
             pass
 
-    @unittest.expectedFailure
     def test_CheckExecuteWrongNoOfArgs3(self):
         # no parameters, parameters are needed
         try:

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -94,10 +94,7 @@ class ModuleTests(unittest.TestCase):
 class ConnectionTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.cx = sqlite.connect(
-            host='host1',
-            port=4001,
-        )
+        cls.cx = sqlite.connect(":memory:")
 
     def setUp(self):
         cu = self.cx.cursor()
@@ -167,7 +164,7 @@ class CursorTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.cx = sqlite.connect(
-            host='host1',
+            host='localhost',
             port=4001,
         )
 
@@ -566,10 +563,7 @@ class ConstructorTests(unittest.TestCase):
 class ExtensionTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.con = sqlite.connect(
-            host='host1',
-            port=4001,
-        )
+        cls.con = sqlite.connect(":memory:")
 
     def tearDown(self):
         for row in self.con.execute(
@@ -652,7 +646,7 @@ class ExtensionTests(unittest.TestCase):
 class ClosedConTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.con = sxxxqlite.connect(":memory:")
+        cls.con = sqlite.connect(":memory:")
         cls.cur = cls.con.cursor()
         cls.con.close()
 
@@ -766,10 +760,7 @@ class ClosedConTests(unittest.TestCase):
 class ClosedCurTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.con = sqlite.connect(
-            host='host1',
-            port=4001,
-        )
+        cls.con = sqlite.connect(":memory:")
         cls.cur = cls.con.cursor()
         cls.cur.close()
 


### PR DESCRIPTION
This PR adds support for named parameters in pyrqlite, for example:

`cu.execute('SELECT name FROM people WHERE name=:name AND age=:age', {'name': 'jeff', 'age': 21})`

The way in which pysqlite processes parameters was used as a template. The additional code is not as pythonic as it could be, there are some quirks around the parameter tests in src/test/test_dbapi.py (class CursorTests) and I wanted to have the new code pass the tests without re-writing them.

CursorTests now references a local rqlite instance.

Tested on Python 2.7 and 3.5 with rqlited v4.3.0