### PR TITLE
_substitute_params: restore parameter sequence code from prior to 5b5fb66f1212

### DIFF
--- a/src/pyrqlite/cursors.py
+++ b/src/pyrqlite/cursors.py
@@ -139,9 +139,13 @@ class Cursor(object):
                 raise ProgrammingError('Named binding used, but you supplied a'
                                        ' sequence (which has no names): %s %s' %
                                        (operation, parameters))
-            for i in range(len(parameters)):
-                operation = operation.replace('?', 
-                                              _adapt_from_python(parameters[i]), 1)
+            parts = operation.split('?')
+            subst = []
+            for i, part in enumerate(parts):
+                subst.append(part)
+                if i < len(parameters):
+                    subst.append(_adapt_from_python(parameters[i]))
+            operation = ''.join(subst)
 
         return operation
 

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -343,7 +343,10 @@ class CursorTests(unittest.TestCase):
 
     def test_CheckRowcountExecute(self):
         self.cu.execute("delete from test")
-        self.cu.execute("insert into test(name) values ('foo')")
+        self.cu.execute("insert into test(name, income) values (?, ?)", ("?", "1"))
+        self.cu.execute("select name from test where name=?", ("?",))
+        self.assertEqual(self.cu.rowcount, 1,
+            msg="test failed for https://github.com/rqlite/pyrqlite/issues/30")
         self.cu.execute("insert into test(name) values ('foo')")
         self.cu.execute("update test set name='bar'")
         self.assertEqual(self.cu.rowcount, 2)


### PR DESCRIPTION
Restore parameter sequence code from prior to commit
5b5fb66f1212. This unit test case demonstrates the problem
reported in https://github.com/rqlite/pyrqlite/issues/30:

This unit test case demonstrates the problem reported in
https://github.com/rqlite/pyrqlite/issues/30:
```python
    def test_CheckRowcountExecute(self):
        self.cu.execute("delete from test")
        self.cu.execute("insert into test(name, income) values (?, ?)", ("?", "1"))
        self.cu.execute("select name from test where name=?", ("?",))
        self.assertEqual(self.cu.rowcount, 1,
            msg="test failed for https://github.com/rqlite/pyrqlite/issues/30")
```
```
src/test/test_dbapi.py:346:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyrqlite.cursors.Cursor object at 0x7f16e1abc400>, operation = "insert into test(name, income) values (''1'', ?)", parameters = ('?', '1')

    def execute(self, operation, parameters=None):
        if not isinstance(operation, basestring):
            raise ValueError(
                             "argument must be a string, not '{}'".format(type(operation).__name__))

        operation = self._substitute_params(operation, parameters)

        command = self._get_sql_command(operation)
        if command in ('SELECT', 'PRAGMA'):
            payload = self._request("GET",
                                    "/db/query?" + _urlencode({'q': operation}))
        else:
            payload = self._request("POST", "/db/execute?transaction",
                                    headers={'Content-Type': 'application/json'}, body=json.dumps([operation]))

        last_insert_id = None
        rows_affected = -1
        payload_rows = {}
        try:
            results = payload["results"]
        except KeyError:
            pass
        else:
            rows_affected = 0
            for item in results:
                if 'error' in item:
                    logging.getLogger(__name__).error(json.dumps(item))
>                   raise Error(json.dumps(item))
E                   sqlite3.Error: {"error": "near \"1\": syntax error"}

pyrqlite/cursors.py:178: Error
```
Note that a similar problem still exists for named parameters, so https://github.com/rqlite/pyrqlite/issues/30 is not entirely fixed.

Reported-by: @jaysonlarose
See: https://github.com/rqlite/pyrqlite/issues/30
Fixes: 5b5fb66f1212 ("Adding support for named parameters")