### PR TITLE
test_dbapi: adapt to python 3.10

### DIFF
--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -25,9 +25,12 @@ from __future__ import print_function
 
 import sys
 try:
-    import test.support as test_support
+    import test.support.warnings_helper as test_support
 except ImportError:
-    from test import test_support
+    try:
+        import test.support as test_support
+    except ImportError:
+        from test import test_support
 import unittest
 
 import pyrqlite.dbapi2 as sqlite


### PR DESCRIPTION
In python 3.10, the check_warnings function was moved into [test.support.warnings_helper](https://docs.python.org/3/library/test.html#test.support.warnings_helper.check_warnings) module. Try this import place before fallback to original modules.

Using this patch, all tests pass on Gentoo using python 3.8, 3.9 and 3.10.

Signed-off-by: Arthur Zamarin <<arthurzam@gentoo.org>>