### PR TITLE
Add support for read consistency levels

### DIFF
--- a/src/pyrqlite/cursors.py
+++ b/src/pyrqlite/cursors.py
@@ -154,7 +154,7 @@ class Cursor(object):
     def _get_sql_command(self, sql_str):
         return sql_str.split(None, 1)[0].upper()
 
-    def execute(self, operation, parameters=None, queue=False, wait=False):
+    def execute(self, operation, parameters=None, queue=False, wait=False, consistency=None):
         if not isinstance(operation, basestring):
             raise ValueError(
                              "argument must be a string, not '{}'".format(type(operation).__name__))
@@ -163,8 +163,10 @@ class Cursor(object):
 
         command = self._get_sql_command(operation)
         if command in ('SELECT', 'PRAGMA'):
-            payload = self._request("GET",
-                                    "/db/query?" + _urlencode({'q': operation}))
+            params = {'q': operation}
+            if consistency:
+                params["level"] = consistency
+            payload = self._request("GET", "/db/query?" + _urlencode(params))
         else:
             path = "/db/execute?transaction"
             if queue:

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -284,6 +284,13 @@ class CursorTests(unittest.TestCase):
         row = self.cu.fetchone()
         self.assertEqual(row[0], "foo")
 
+    def test_CheckExecuteParamListConsistency(self):
+        self.cu.execute("insert into test(name) values ('foo')")
+        for c in ['strong', 'weak', 'none', None]:
+            self.cu.execute("select name from test where name=?", ["foo"], consistency=c)
+            row = self.cu.fetchone()
+            self.assertEqual(row[0], "foo")
+
     def test_CheckExecuteParamSequence(self):
         class L(object):
             def __len__(self):


### PR DESCRIPTION
Adds optional param in Cursor.execute which allows the caller to set a read consistency level.

See https://rqlite.io/docs/api/read-consistency/