### PR TITLE
Row: Allow non-unique column names like sqlite3.Row

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 
+## 2.2.2 (Jan 21 2024)
+- [PR #59](https://github.com/rqlite/pyrqlite/pull/59): Row: Allow non-unique column names.
+
 ## 2.2.1 (Jan 3 2024)
 - [PR #57](https://github.com/rqlite/pyrqlite/issues/57): Add project.license to pyproject.toml.
 

--- a/README.rst
+++ b/README.rst
@@ -83,8 +83,8 @@ The following code creates a connection and executes some statements:
 This example will print:
 
 
-    OrderedDict([('id', 1), ('name', 'a')])
-    OrderedDict([('id', 2), ('name', 'b')])
+    (1, 'a')
+    (2, 'b')
     
 Paramstyle
 ---------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyrqlite"
-version = "2.2.1"
+version = "2.2.2"
 authors = [
   { name="Zac Medico", email="zmedico@gmail.com" },
   { name="Philip O'Toole", email="philip.otoole@yahoo.com" },
@@ -13,6 +13,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dynamic = ["maintainers"]
 
 [project.license]
 file = "LICENSE"

--- a/src/test/test_row.py
+++ b/src/test/test_row.py
@@ -1,5 +1,46 @@
+import unittest
 
+import pyrqlite.dbapi2 as sqlite
 from pyrqlite.row import Row
+
+
+class NonUniqueColumnsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cx = sqlite.connect(":memory:")
+
+    def setUp(self):
+        """
+        Create tables to join with some columns that have the same names,
+        to demonstrated rows with non-unique column names.
+        """
+        self.cu = self.cx.cursor()
+        self.cu.execute("create table tbl1(id integer primary key, name text)")
+        self.cu.execute("insert into tbl1(id, name) values (1, 'foo')")
+        self.cu.execute(
+            "create table tbl2(id integer primary key, tbl1id integer, name text)"
+        )
+        self.cu.execute("insert into tbl2(id, tbl1id, name) values (2, 1, 'bar')")
+
+    def tearDown(self):
+        self.cu.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cx.close()
+        del cls.cx
+
+    def testJoin(self):
+        """
+        Test a join that demonstrates rows with non-unique column names.
+        """
+        self.cu.execute("select * from tbl1 inner join tbl2 on tbl2.tbl1id = tbl1.id")
+        row = self.cu.fetchone()
+        self.assertEqual(tuple(row.keys()), ("id", "name", "id", "tbl1id", "name"))
+        self.assertEqual(tuple(row.values()), (1, "foo", 2, 1, "bar"))
+        self.assertEqual(row["name"], "foo")
+        self.assertEqual(row["id"], 1)
+        self.assertEqual(row["tbl1id"], 1)
 
 
 def test_row():
@@ -23,3 +64,17 @@ def test_row():
         pass
     else:
         assert False
+
+
+def test_row_with_non_unique_columns():
+    items = [("foo", "foo"), ("bar", "bar"), ("foo", "bar")]
+    row = Row(items)
+    assert len(row) == 3
+
+    assert row["foo"] == "foo"
+    assert row["bar"] == "bar"
+    assert row[0] == "foo"
+    assert row[1] == "bar"
+    assert row[2] == "bar"
+    assert list(row.items()) == items
+    assert list(row.values()) == [item[1] for item in items]


### PR DESCRIPTION
* keys method now returns a list of column names which are not necessarily unique

* `__getitem__` method now returns the value corresponding to the first matching column name

* items and values methods can now return multiple items or values that correspond to the same key (like multidict)

* `__str__` method now inherits the tuple implementation since dict requires unique keys

Closes: https://github.com/rqlite/pyrqlite/issues/58