### PR TITLE
Sort params named_matches by len

### DIFF
--- a/src/pyrqlite/cursors.py
+++ b/src/pyrqlite/cursors.py
@@ -88,69 +88,6 @@ class Cursor(object):
                     indent=4))
         return response_json
 
-    def _substitute_params(self, operation, parameters):
-        '''
-        SQLite natively supports only the types TEXT, INTEGER, REAL, BLOB and
-        NULL
-        '''
-
-        param_matches = 0
-
-        qmark_re = re.compile(r"(\?)")
-        named_re = re.compile(r"(:{1}[a-zA-Z_]+?\b)")
-
-        qmark_matches = qmark_re.findall(operation)
-        named_matches = named_re.findall(operation)
-        param_matches = len(qmark_matches) + len(named_matches)
-
-        # Matches but no parameters
-        if param_matches > 0 and parameters is None:
-            raise ProgrammingError('parameter required but not given: %s' %
-                                   operation)
-
-        # No regex matches and no parameters.
-        if parameters is None:
-            return operation
-
-        if len(qmark_matches) > 0 and len(named_matches) > 0:
-            raise ProgrammingError('different parameter types in operation not'
-                                   'permitted: %s %s' % 
-                                   (operation, parameters))
-
-        if isinstance(parameters, dict):
-            # parameters is a dict or a dict subclass
-            if len(qmark_matches) > 0:
-                raise ProgrammingError('Unamed binding used, but you supplied '
-                                       'a dictionary (which has only names): '
-                                       '%s %s' % (operation, parameters))
-            for op_key in sorted(named_matches, key=len, reverse=True):
-                try:
-                    operation = operation.replace(op_key, 
-                                                 _adapt_from_python(parameters[op_key[1:]]))
-                except KeyError:
-                    raise ProgrammingError('the named parameters given do not '
-                                           'match operation: %s %s' %
-                                           (operation, parameters))
-        else:
-            # parameters is a sequence
-            if param_matches != len(parameters):
-                raise ProgrammingError('incorrect number of parameters '
-                                       '(%s != %s): %s %s' % (param_matches, 
-                                       len(parameters), operation, parameters))
-            if len(named_matches) > 0:
-                raise ProgrammingError('Named binding used, but you supplied a'
-                                       ' sequence (which has no names): %s %s' %
-                                       (operation, parameters))
-            parts = operation.split('?')
-            subst = []
-            for i, part in enumerate(parts):
-                subst.append(part)
-                if i < len(parameters):
-                    subst.append(_adapt_from_python(parameters[i]))
-            operation = ''.join(subst)
-
-        return operation
-
     def _get_sql_command(self, sql_str):
         return sql_str.split(None, 1)[0].upper()
 
@@ -159,22 +96,30 @@ class Cursor(object):
             raise ValueError(
                              "argument must be a string, not '{}'".format(type(operation).__name__))
 
-        operation = self._substitute_params(operation, parameters)
-
         command = self._get_sql_command(operation)
         if command in ('SELECT', 'PRAGMA'):
-            params = {'q': operation}
+            path = "/db/query?"
             if consistency:
-                params["level"] = consistency
-            payload = self._request("GET", "/db/query?" + _urlencode(params))
+                path = path + "level=" + consistency
         else:
             path = "/db/execute?transaction"
             if queue:
                 path = path + "&queue"
             if wait:
                 path = path +"&wait"
-            payload = self._request("POST", path,
-                                    headers={'Content-Type': 'application/json'}, body=json.dumps([operation]))
+
+        body = [operation]
+        if isinstance(parameters, list):
+            body = body + parameters
+        if isinstance(parameters, dict):
+            body.append(parameters)
+        if isinstance(parameters, tuple):
+            body = body + list(parameters)
+
+        payload = self._request("POST", path,
+                                headers={'Content-Type': 'application/json'},
+                                body=json.dumps([body])
+                            )
 
         last_insert_id = None
         rows_affected = -1

--- a/src/pyrqlite/cursors.py
+++ b/src/pyrqlite/cursors.py
@@ -97,7 +97,7 @@ class Cursor(object):
         param_matches = 0
 
         qmark_re = re.compile(r"(\?)")
-        named_re = re.compile(r"(:{1}[a-zA-Z]+?\b)")
+        named_re = re.compile(r"(:{1}[a-zA-Z_]+?\b)")
 
         qmark_matches = qmark_re.findall(operation)
         named_matches = named_re.findall(operation)
@@ -123,7 +123,7 @@ class Cursor(object):
                 raise ProgrammingError('Unamed binding used, but you supplied '
                                        'a dictionary (which has only names): '
                                        '%s %s' % (operation, parameters))
-            for op_key in named_matches:
+            for op_key in sorted(named_matches, key=len, reverse=True):
                 try:
                     operation = operation.replace(op_key, 
                                                  _adapt_from_python(parameters[op_key[1:]]))


### PR DESCRIPTION
This searches for larger (more specific) matches first so that for example `gameid` and `game` get matched independently. I found this operated differently from the sqlite3 library, here's some test code.

```
import pyrqlite.dbapi2 as dbapi2

connection = dbapi2.connect(host="localhost", port=4001)
cursor = connection.cursor()
values = {
    "id": 42069,
    "round": 2,
    "roundname": "Round 2"
}
cursor.execute("CREATE TABLE IF NOT EXISTS foo ( id integer not null primary key, round integer not null, roundname text not null)")

cursor.execute("INSERT INTO foo VALUES(:id, :round, :roundname)", values)
```

Without the sort, it replaces both `round` strings first, without giving the chance of replacing `roundname` to its correct value.

I also added _ to regex to match for params specified as match_id, and from looking at the sqlite docs it seems like table names have a very loose definition for [what passes as a table name](https://www.sqlite.org/lang_createtable.html) (with quotes apparently its free game). Not sure how you'd want to handle this one, but from what I remember the regular sqlite3 library did handle the underscores without issue.

Please let me know if you'd like me to modify anything or add a test to catch these in the future. Cheers!