### PR TITLE
Support parameterization API and detect_types 

### DIFF
--- a/src/pyrqlite/cursors.py
+++ b/src/pyrqlite/cursors.py
@@ -125,7 +125,9 @@ class Cursor(object):
                                        'a dictionary (which has only names): '
                                        '%s %s' % (operation, parameters))
             for op_key in named_matches:
-                if not op_key[1:] in parameters:
+                try:
+                    parameters[op_key[1:]]
+                except KeyError:
                     raise ProgrammingError('the named parameters given do not '
                                            'match operation: %s %s' %
                                            (operation, parameters))

--- a/src/pyrqlite/cursors.py
+++ b/src/pyrqlite/cursors.py
@@ -155,9 +155,13 @@ class Cursor(object):
         operation = [operation]
         if parameters is not None:
             if isinstance(parameters, dict):
-                operation.append(parameters)
+                adapted_parameters = {key: _adapt_from_python(value)
+                                      for key, value in parameters.items()}
+                operation.append(adapted_parameters)
             else:
-                operation.extend(parameters)
+                adapted_parameters = [_adapt_from_python(value)
+                                      for value in parameters]
+                operation.extend(adapted_parameters)
 
         command = self._get_sql_command(operation[0])
         if command in ('SELECT', 'PRAGMA'):
@@ -264,9 +268,13 @@ class Cursor(object):
             new_operation = [operation]
             if parameters is not None:
                 if isinstance(parameters, dict):
-                    new_operation.append(parameters)
+                    adapted_parameters = {key: _adapt_from_python(value)
+                                        for key, value in parameters.items()}
+                    new_operation.append(adapted_parameters)
                 else:
-                    new_operation.extend(parameters)
+                    adapted_parameters = [_adapt_from_python(value)
+                                        for value in parameters]
+                    new_operation.extend(adapted_parameters)
             statements.append(new_operation)
 
         path = "/db/execute?transaction"

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -233,7 +233,6 @@ class CursorTests(unittest.TestCase):
     def test_CheckExecuteArgString(self):
         self.cu.execute("insert into test(name) values (?)", ("Hugo",))
 
-    @unittest.expectedFailure
     def test_CheckExecuteArgStringWithZeroByte(self):
         self.cu.execute("insert into test(name) values (?)", ("Hu\x00go",))
 

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -287,9 +287,15 @@ class CursorTests(unittest.TestCase):
         class L(object):
             def __len__(self):
                 return 1
+
             def __getitem__(self, x):
-                assert x == 0
+                if x >= self.__len__():
+                    raise IndexError("Index out of range")
                 return "foo"
+
+            def __iter__(self):
+                for i in range(self.__len__()):
+                    yield self[i]
 
         self.cu.execute("insert into test(name) values ('foo')")
         self.cu.execute("select name from test where name=?", L())

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -358,6 +358,14 @@ class CursorTests(unittest.TestCase):
         self.cu.close()
         self.cu = self.cx.cursor()
 
+    def test_CheckExecuteWithQmarkInString(self):
+        # check qmark in a string is not interpreted as a parameter placeholder
+        self.cu.execute("create table testq(id integer primary key, name text default 'bar?')")
+
+    def test_CheckExecuteWithColonInString(self):
+        # check colon in a string is not interpreted as a named parameter placeholder
+        self.cu.execute("create table testc(id integer primary key, name text default 'foo:bar:')")
+
     def test_CheckRowcountExecute(self):
         self.cu.execute("delete from test")
         self.cu.execute("insert into test(name, income) values (?, ?)", ("?", "1"))

--- a/src/test/test_types.py
+++ b/src/test/test_types.py
@@ -253,7 +253,6 @@ class DeclTypesTests(unittest.TestCase):
         with self.assertRaises(sqlite.InterfaceError):
             self.cur.execute("insert into test(f) values (?)", (val,))
 
-    @unittest.skip('named paramstyle is not implemented')
     def test_CheckUnsupportedDict(self):
         class Bar: pass
         val = Bar()

--- a/src/test/test_types.py
+++ b/src/test/test_types.py
@@ -427,7 +427,7 @@ class ObjectAdaptationTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del sqlite.adapters[(int, sqlite.PrepareProtocol)]
+        del sqlite.adapters[int]
         cls.cur.close()
         cls.con.close()
 


### PR DESCRIPTION
Hi,

This PR introduces changes to address two issues:

- `DATE` and `TIMESTAMP` fields are always parsed into a python type regardless of the `detect_types` flag
- substitution of parameters will catch placeholder symbols inside string literals within the statement

In summary the changes are:

- use rqlite's parameterization API
- split the converters: default converters always need to run to handle primitive types, and the rest do additional parsing only if enabled through `detect_types`

Unfortunately there are a couple of breaking changes:

- removal of support for the `sqlite3.PrepareProtocol` since we now need to adapt from python to the JSON API instead of a SQL statement
- if `detect_types` is not specified then `DATE` and `TIMESTAMP` fields will not be parsed

Happy to take feedback / discuss / improve this PR if you think these changes can be merged.

I originally started this work trying to get some sqlalchemy based projects working with rqlite. Even though it is not a stated goal of pyrqlite to be 1-1 compatible with sqlite3 module, I figured aligning the critical bits here was better than working around in the sqlalchemy-rqlite package.

Cheers!