### PR TITLE
Use params API

### DIFF
--- a/src/pyrqlite/cursors.py
+++ b/src/pyrqlite/cursors.py
@@ -201,8 +201,9 @@ class Cursor(object):
                                        '%s %s' % (operation, parameters))
             for op_key in named_matches:
                 try:
-                    # Access the key to trigger defaultdict creation if needed
-                    # otherwise check for KeyError for normal dict
+                    # if parameters is a defaultdict, we need to access op_key
+                    # to trigger defaultdict creation if needed.
+                    # otherwise when its a normal dict, check for KeyError
                     _ = parameters[op_key]
                 except KeyError:
                     raise ProgrammingError('the named parameters given do not '

--- a/src/pyrqlite/cursors.py
+++ b/src/pyrqlite/cursors.py
@@ -143,7 +143,7 @@ class Cursor(object):
         qmark_matches = qmark_re.findall(operation)
         return [match for match in qmark_matches]
 
-    def _resolve_named_params(self, operation, parameters, named_params):
+    def _resolve_named_params(self, operation, parameters):
         '''
         This function resolves all the named parameters extracted from the operation
         string against the parameters object given
@@ -154,6 +154,7 @@ class Cursor(object):
                                    'a sequence (which has no names): %s %s' %
                                    (operation, parameters))
 
+        named_params = self._get_named_params(operation)
         resolved_params = {}
 
         for param in named_params:
@@ -240,8 +241,7 @@ class Cursor(object):
             if isinstance(parameters, dict):
                 # we need to use the key names matched from the operation to resolve against
                 # the dict like object given in parameters
-                resolved_params = self._resolve_named_params(operation,
-                    parameters, self._get_named_params(operation))
+                resolved_params = self._resolve_named_params(operation, parameters)
                 adapted_parameters = {key: _adapt_from_python(value)
                                         for key, value in resolved_params.items()}
                 op_payload.append(adapted_parameters)

--- a/src/pyrqlite/cursors.py
+++ b/src/pyrqlite/cursors.py
@@ -14,7 +14,7 @@ except ImportError:
     # pylint: disable=no-name-in-module
     from urllib import urlencode
 
-from .exceptions import Error, ProgrammingError
+from .exceptions import Error, ProgrammingError, InterfaceError
 
 from .row import Row
 from .extensions import _convert_to_python, _adapt_from_python, _column_stripper
@@ -88,19 +88,95 @@ class Cursor(object):
                     indent=4))
         return response_json
 
-    def _substitute_params(self, operation, parameters):
+    def _get_sql_command(self, sql_str):
+        return sql_str.split(None, 1)[0].upper()
+    
+    def _strip_strings(self, operation):
         '''
-        SQLite natively supports only the types TEXT, INTEGER, REAL, BLOB and
-        NULL
+        This function removes string literals from the SQL operation so we
+        avoid matching any parameter placeholders inside them.
+        '''
+        result = []
+        in_single_quote = False
+        in_double_quote = False
+        escape = False
+
+        for char in operation:
+            if escape:
+                escape = False
+                continue
+
+            if char == "\\":
+                escape = True
+                continue
+
+            if char == "'" and not in_double_quote:
+                in_single_quote = not in_single_quote
+                continue
+
+            if char == '"' and not in_single_quote:
+                in_double_quote = not in_double_quote
+                continue
+
+            if not in_single_quote and not in_double_quote:
+                result.append(char)
+
+        return ''.join(result)
+    
+    def _get_named_params(self, operation):
+        '''
+        This function returns a list of named parameters in the operation
+        string.
+        '''
+        operation = self._strip_strings(operation)
+        named_re = re.compile(r"(:{1}[a-zA-Z]+?\b)")
+        named_matches = named_re.findall(operation)
+        return [match[1:] for match in named_matches]
+
+    def _get_qmark_params(self, operation):
+        '''
+        This function returns a list of qmark parameters in the operation
+        string.
+        '''
+        operation = self._strip_strings(operation)
+        qmark_re = re.compile(r"(\?)")
+        qmark_matches = qmark_re.findall(operation)
+        return [match for match in qmark_matches]
+
+    def _resolve_named_params(self, operation, parameters, named_params):
+        '''
+        This function resolves all the named parameters extracted from the operation
+        string against the parameters object given
+        '''
+
+        if not isinstance(parameters, dict):
+            raise ProgrammingError('named parameters used, but you supplied '
+                                   'a sequence (which has no names): %s %s' %
+                                   (operation, parameters))
+
+        resolved_params = {}
+
+        for param in named_params:
+            try:
+                resolved_params[param] = parameters[param]
+            except KeyError:
+                raise ProgrammingError('the named parameters given do not '
+                                       'match operation: %s %s' %
+                                       (operation, parameters))
+        
+        return resolved_params
+    
+    def _check_params_count(self, operation, parameters):
+        '''
+        This function doesn't perform substitution, it just checks
+        the number of parameters in the operation against the
+        number of parameters given
         '''
 
         param_matches = 0
 
-        qmark_re = re.compile(r"(\?)")
-        named_re = re.compile(r"(:{1}[a-zA-Z]+?\b)")
-
-        qmark_matches = qmark_re.findall(operation)
-        named_matches = named_re.findall(operation)
+        qmark_matches = self._get_qmark_params(operation)
+        named_matches = self._get_named_params(operation)
         param_matches = len(qmark_matches) + len(named_matches)
 
         # Matches but no parameters
@@ -110,7 +186,7 @@ class Cursor(object):
 
         # No regex matches and no parameters.
         if parameters is None:
-            return operation
+            return
 
         if len(qmark_matches) > 0 and len(named_matches) > 0:
             raise ProgrammingError('different parameter types in operation not'
@@ -125,8 +201,9 @@ class Cursor(object):
                                        '%s %s' % (operation, parameters))
             for op_key in named_matches:
                 try:
-                    operation = operation.replace(op_key, 
-                                                 _adapt_from_python(parameters[op_key[1:]]))
+                    # Access the key to trigger defaultdict creation if needed
+                    # otherwise check for KeyError for normal dict
+                    _ = parameters[op_key]
                 except KeyError:
                     raise ProgrammingError('the named parameters given do not '
                                            'match operation: %s %s' %
@@ -141,32 +218,57 @@ class Cursor(object):
                 raise ProgrammingError('Named binding used, but you supplied a'
                                        ' sequence (which has no names): %s %s' %
                                        (operation, parameters))
-            parts = operation.split('?')
-            subst = []
-            for i, part in enumerate(parts):
-                subst.append(part)
-                if i < len(parameters):
-                    subst.append(_adapt_from_python(parameters[i]))
-            operation = ''.join(subst)
 
-        return operation
+        return
+    
+    def _get_operation_with_params(self, operation, parameters):
+        """
+        Construct the operation for the rqlite API with adapted parameters, like:
 
-    def _get_sql_command(self, sql_str):
-        return sql_str.split(None, 1)[0].upper()
+        named param style:
+        ["select name from test where name=:name", {"name": "foo"}]
+        
+        qmark style:
+        ["insert into test(dt) values (?)", "2025-08-04 10:36:19.581096"]
+        """
+        # check parameters provided match with what we expect from the operation
+        self._check_params_count(operation, parameters)
+        # create the operation payload
+        op_payload = [operation]
+        if parameters is not None:
+            if isinstance(parameters, dict):
+                # we need to use the key names matched from the operation to resolve against
+                # the dict like object given in parameters
+                resolved_params = self._resolve_named_params(operation,
+                    parameters, self._get_named_params(operation))
+                adapted_parameters = {key: _adapt_from_python(value)
+                                        for key, value in resolved_params.items()}
+                op_payload.append(adapted_parameters)
+            else:
+                adapted_parameters = [_adapt_from_python(value)
+                                      for value in parameters]
+                op_payload.extend(adapted_parameters)
+        
+        return op_payload
 
     def execute(self, operation, parameters=None, queue=False, wait=False, consistency=None):
         if not isinstance(operation, basestring):
             raise ValueError(
                              "argument must be a string, not '{}'".format(type(operation).__name__))
 
-        operation = self._substitute_params(operation, parameters)
+        try:
+            statements = json.dumps([self._get_operation_with_params(operation, parameters)])
+        except TypeError as e:
+            raise InterfaceError(e)
 
         command = self._get_sql_command(operation)
         if command in ('SELECT', 'PRAGMA'):
-            params = {'q': operation}
+            params = {}
             if consistency:
                 params["level"] = consistency
-            payload = self._request("GET", "/db/query?" + _urlencode(params))
+            payload = self._request("POST", "/db/query?" + _urlencode(params), 
+                                    headers={'Content-Type': 'application/json'},
+                                    body=statements)
         else:
             path = "/db/execute?transaction"
             if queue:
@@ -174,7 +276,8 @@ class Cursor(object):
             if wait:
                 path = path +"&wait"
             payload = self._request("POST", path,
-                                    headers={'Content-Type': 'application/json'}, body=json.dumps([operation]))
+                                    headers={'Content-Type': 'application/json'},
+                                    body=statements)
 
         last_insert_id = None
         rows_affected = -1
@@ -188,7 +291,7 @@ class Cursor(object):
             for item in results:
                 if 'error' in item:
                     logging.getLogger(__name__).error(json.dumps(item))
-                    raise Error(json.dumps(item))
+                    raise ProgrammingError(json.dumps(item))
                 try:
                     rows_affected += item['rows_affected']
                 except KeyError:
@@ -258,7 +361,10 @@ class Cursor(object):
 
         statements = []
         for parameters in seq_of_parameters:
-            statements.append(self._substitute_params(operation, parameters))
+            try:
+                statements.append(self._get_operation_with_params(operation, parameters))
+            except TypeError as e:
+                raise InterfaceError(e)
 
         path = "/db/execute?transaction"
         if queue:
@@ -278,6 +384,7 @@ class Cursor(object):
             for item in results:
                 if 'error' in item:
                     logging.getLogger(__name__).error(json.dumps(item))
+                    raise ProgrammingError(json.dumps(item))
                 try:
                     rows_affected += item['rows_affected']
                 except KeyError:

--- a/src/pyrqlite/cursors.py
+++ b/src/pyrqlite/cursors.py
@@ -292,7 +292,8 @@ class Cursor(object):
             for item in results:
                 if 'error' in item:
                     logging.getLogger(__name__).error(json.dumps(item))
-                    raise ProgrammingError(json.dumps(item))
+                    # error will be a string with description of the error
+                    raise ProgrammingError(item['error'])
                 try:
                     rows_affected += item['rows_affected']
                 except KeyError:
@@ -385,7 +386,7 @@ class Cursor(object):
             for item in results:
                 if 'error' in item:
                     logging.getLogger(__name__).error(json.dumps(item))
-                    raise ProgrammingError(json.dumps(item))
+                    raise ProgrammingError(item['error'])
                 try:
                     rows_affected += item['rows_affected']
                 except KeyError:

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -289,8 +289,7 @@ class CursorTests(unittest.TestCase):
                 return 1
 
             def __getitem__(self, x):
-                if x >= self.__len__():
-                    raise IndexError("Index out of range")
+                assert x == 0 
                 return "foo"
 
             def __iter__(self):

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -233,7 +233,6 @@ class CursorTests(unittest.TestCase):
     def test_CheckExecuteArgString(self):
         self.cu.execute("insert into test(name) values (?)", ("Hugo",))
 
-    @unittest.expectedFailure
     def test_CheckExecuteArgStringWithZeroByte(self):
         self.cu.execute("insert into test(name) values (?)", ("Hu\x00go",))
 

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -288,9 +288,16 @@ class CursorTests(unittest.TestCase):
         class L(object):
             def __len__(self):
                 return 1
+
             def __getitem__(self, x):
                 assert x == 0
+                if x >= self.__len__():
+                    raise IndexError("Index out of range")
                 return "foo"
+
+            def __iter__(self):
+                for i in range(self.__len__()):
+                    yield self[i]
 
         self.cu.execute("insert into test(name) values ('foo')")
         self.cu.execute("select name from test where name=?", L())

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -289,7 +289,7 @@ class CursorTests(unittest.TestCase):
                 return 1
 
             def __getitem__(self, x):
-                assert x == 0 
+                assert x == 0
                 return "foo"
 
             def __iter__(self):

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -289,7 +289,6 @@ class CursorTests(unittest.TestCase):
                 return 1
 
             def __getitem__(self, x):
-                assert x == 0
                 if x >= self.__len__():
                     raise IndexError("Index out of range")
                 return "foo"

--- a/src/test/test_dbapi.py
+++ b/src/test/test_dbapi.py
@@ -353,6 +353,14 @@ class CursorTests(unittest.TestCase):
         except sqlite.ProgrammingError:
             pass
 
+    def test_CheckExecuteWithQmarkInString(self):
+        # check qmark in a string is not interpreted as a parameter placeholder
+        self.cu.execute("create table testq(id integer primary key, name text default 'bar?')")
+
+    def test_CheckExecuteWithColonInString(self):
+        # check colon in a string is not interpreted as a named parameter placeholder
+        self.cu.execute("create table testc(id integer primary key, name text default 'foo:bar:')")
+
     def test_CheckClose(self):
         self.cu.close()
         self.cu = self.cx.cursor()

--- a/src/test/test_types.py
+++ b/src/test/test_types.py
@@ -253,7 +253,6 @@ class DeclTypesTests(unittest.TestCase):
         with self.assertRaises(sqlite.InterfaceError):
             self.cur.execute("insert into test(f) values (?)", (val,))
 
-    @unittest.skip('named paramstyle is not implemented')
     def test_CheckUnsupportedDict(self):
         class Bar: pass
         val = Bar()


### PR DESCRIPTION
This PR makes pyrqlite use the params API instead of client side string substitution.

It fixes an issue where placeholder characters could not appear inside string literals in the SQL statement.

It also potentially improves security by allowing the server to prepare and bind the parameters.

These changes should not break existing use cases for pyrqlite.